### PR TITLE
Changelog and update repo-small-badge version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Change Logs
+
+# Version 0.2.1
+
+* Add CHANGELOG
+* Support SVG
+* Support 0.2.2 repo-small-badge gem

--- a/lib/simplecov_small_badge/configuration.rb
+++ b/lib/simplecov_small_badge/configuration.rb
@@ -8,7 +8,6 @@ module SimpleCovSmallBadge
     # rubocop:disable Metrics/MethodLength
     def self.options
       {
-        format: 'svg',
         with_groups: false,
         background: '#fff',
         title_prefix: 'scov',

--- a/lib/simplecov_small_badge/version.rb
+++ b/lib/simplecov_small_badge/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SimpleCovSmallBadge
-  VERSION = '0.2'
+  VERSION = '0.2.1'
 end

--- a/script/travis.sh
+++ b/script/travis.sh
@@ -1,12 +1,14 @@
 #!/bin/sh
 set -e
 RUBYCRITICLIMIT=${RUBYCRITICLIMIT:-"90.0"}
+QUICK=${QUICK:-}
 
 bundle exec rspec
 bundle exec rubocop
-gem install bundler-audit && bundle-audit update && bundle-audit check
-gem install rubycritic && rubycritic app lib config ${RUBYCRITICPARAMS} --format console --minimum-score ${RUBYCRITICLIMIT}
-echo "Pushing badges upstream"
-[ -d badges ] || mkdir badges
-cp coverage/coverage_badge* badges/
-ls badges
+if [ -z "$QUICK" ]; then
+  gem install bundler-audit && bundle-audit update && bundle-audit check
+  gem install rubycritic && rubycritic app lib config ${RUBYCRITICPARAMS} --format console --minimum-score ${RUBYCRITICLIMIT}
+  echo "Pushing badges upstream"
+  [ -d badges ] || mkdir badges
+  cp coverage/coverage_badge* badges/ 2>/dev/null || true
+fi

--- a/simplecov-small-badge.gemspec
+++ b/simplecov-small-badge.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = 'simplecov-small-badge'
 
-  s.add_dependency 'repo-small-badge', '~> 0.2.1'
+  s.add_dependency 'repo-small-badge', '~> 0.2.2'
   s.add_dependency 'simplecov', '~> 0.16'
   s.add_development_dependency 'rake', '~> 12'
   s.add_development_dependency 'rspec', '~> 3.8'


### PR DESCRIPTION
* Added changelog
* Update to repo-small-badge version 0.2.2 because of proper svg support.